### PR TITLE
give ndncert more breathing time

### DIFF
--- a/src/components/connect/ndn-testbed.tsx
+++ b/src/components/connect/ndn-testbed.tsx
@@ -18,6 +18,7 @@ import { TestbedAnchorName } from "../../constants"
 import { bytesToBase64 } from "../../utils"
 import { Encoder } from "@ndn/tlv"
 import { WsTransport } from "@ndn/ws-transport"
+import { Endpoint } from "@ndn/endpoint";
 
 type Resolver = { resolve: (pin: string | PromiseLike<string>) => void }
 
@@ -91,6 +92,12 @@ export default function NdnTestbed(props: {
 
       // New step
       const cert = await ndncert.requestCertificate({
+        endpoint: new Endpoint({
+          retx: {
+            limit: 4,
+            interval: 5000,
+          }
+        }),
         profile: caProfile,
         privateKey: prvKey,
         publicKey: pubKey,


### PR DESCRIPTION
NDNts retransmits the challenge interest too fast, which doesn't play nice because (presumably?) this generates two separate challegnge requests. After this, the first request is used for sending the challenge response, which doesn't exist anymore (?).

The solution is to prevent the retransmission unless we're quite sure that the interest was lost (after lifetime expires). (note the default is to retransmit at half the interest lifetime)

P.S. I'm not sure; maybe this can be considered a bug in NDNts (or what)

cc @yoursunny