### PR TITLE
File-list scrolling with `maxHeight` and `overflowY` settings

### DIFF
--- a/src/components/share-latex/file-list.tsx
+++ b/src/components/share-latex/file-list.tsx
@@ -52,7 +52,7 @@ export default function FileList(props: {
   }
 
   return (
-    <TableContainer component={Paper}>
+    <TableContainer component={Paper} sx={{ maxHeight: '650px', overflowY: 'auto' }}>
       <Table sx={{ minWidth: 650 }}>
         <TableHead>
           <TableRow>


### PR DESCRIPTION
Added `maxHeight` and `overflowY` settings to the `TableContainer` holding the file list. This should solve #74 