### PR TITLE
Showing version in git tag

### DIFF
--- a/build-meta.bash
+++ b/build-meta.bash
@@ -1,4 +1,4 @@
-revision=$(git rev-parse --short HEAD)
+revision=$(git describe --tags --abbrev=0)
 timestamp=$(date +%s.%N)
 echo '{"revision":"'${revision}'","timestamp":'${timestamp}'}' > ./public/build-meta.json
 echo 'export const REVISION = '"'"${revision}"'" \


### PR DESCRIPTION
git describe --tags --abbrev=0 shows the closest tag, resolves #89 .