### PR TITLE
Display Credentials as QR Code

### DIFF
--- a/src/components/workspace/app-namespace.tsx
+++ b/src/components/workspace/app-namespace.tsx
@@ -10,6 +10,7 @@ import { Decoder, Encoder } from '@ndn/tlv'
 import { Data } from '@ndn/packet'
 import { Certificate } from '@ndn/keychain'
 import QrReader from './qr-read'
+import CertQrCode from './qr-gen'
 
 export default function AppNamespace(props: {
   trustAnchor: Certificate | undefined
@@ -132,26 +133,31 @@ export default function AppNamespace(props: {
       <Show when={expanded()}>
         <Divider />
         <CardContent>
-          <TextField
-            fullWidth
-            required
-            multiline
-            label="Trust Anchor"
-            name="trust-anchor"
-            type="text"
-            rows={10}
-            inputProps={{
-              style: {
-                'font-family': '"Roboto Mono", ui-monospace, monospace',
-                'white-space': 'pre',
-              },
-            }}
-            // disabled={readOnly()}  // disabled not working with multiline
-            helperText={errorText()}
-            error={errorText() != ''}
-            value={value()}
-            onChange={(event) => onChange(event.target.value)}
-          />
+          <div style={{ display: 'flex', 'flex-direction': 'row', 'align-items': 'center' }}>
+            <TextField
+              fullWidth
+              required
+              multiline
+              label="Trust Anchor"
+              name="trust-anchor"
+              type="text"
+              rows={14}
+              inputProps={{
+                style: {
+                  'font-family': '"Roboto Mono", ui-monospace, monospace',
+                  'white-space': 'pre',
+                },
+              }}
+              // disabled={readOnly()}  // disabled not working with multiline
+              helperText={errorText()}
+              error={errorText() != ''}
+              value={value()}
+              onChange={(event) => onChange(event.target.value)}
+            />
+            <div>
+              <CertQrCode value={value()} />
+            </div>
+          </div>
         </CardContent>
       </Show>
     </Card>

--- a/src/components/workspace/own-certificate.tsx
+++ b/src/components/workspace/own-certificate.tsx
@@ -4,13 +4,12 @@ import { Show, createEffect, createSignal } from 'solid-js'
 import { bytesToBase64 } from '../../utils'
 import { Encoder } from '@ndn/tlv'
 import { Certificate } from '@ndn/keychain'
-import { toDataURL } from 'qrcode'
+import CertQrCode from './qr-gen'
 
 export default function OwnCertificate(props: { certificate: Certificate | undefined }) {
   const [expanded, setExpanded] = createSignal(true)
   const [nameStr, setNameStr] = createSignal('')
   const [certText, setCertText] = createSignal('')
-  const [qrCodeUrl, setQrCodeUrl] = createSignal('')
 
   createEffect(() => {
     const cert = props.certificate
@@ -32,17 +31,6 @@ export default function OwnCertificate(props: { certificate: Certificate | undef
       setNameStr('')
       setCertText('')
     }
-  })
-
-  // Generate QR-Code when certText change
-  createEffect(() => {
-    toDataURL(certText(), { errorCorrectionLevel: 'M' }) // TODO: hardcoded error-level
-      .then((url) => {
-        setQrCodeUrl(url)
-      })
-      .catch((e) => {
-        console.error('Error generating QR code', e)
-      })
   })
 
   return (
@@ -84,7 +72,7 @@ export default function OwnCertificate(props: { certificate: Certificate | undef
               value={certText()}
             />
             <div>
-              <img src={qrCodeUrl()} alt="QR Code" style={{ 'margin-left': '15px' }} />
+              <CertQrCode value={certText()} />
             </div>
           </div>
         </CardContent>

--- a/src/components/workspace/own-certificate.tsx
+++ b/src/components/workspace/own-certificate.tsx
@@ -54,7 +54,7 @@ export default function OwnCertificate(props: { certificate: Certificate | undef
       <Show when={expanded()}>
         <Divider />
         <CardContent>
-          <div style={{ display: 'flex', 'align-items': 'flex-start' }}>
+          <div style={{ display: 'flex', 'flex-direction': 'row', 'align-items': 'center' }}>
             <TextField
               fullWidth
               multiline

--- a/src/components/workspace/own-certificate.tsx
+++ b/src/components/workspace/own-certificate.tsx
@@ -73,7 +73,7 @@ export default function OwnCertificate(props: { certificate: Certificate | undef
               label="My Certificate"
               name="certificate"
               type="text"
-              rows={10}
+              rows={14}
               inputProps={{
                 // readOnly: true,  // readOnly does not work with multiline
                 style: {
@@ -84,7 +84,7 @@ export default function OwnCertificate(props: { certificate: Certificate | undef
               value={certText()}
             />
             <div>
-              <img src={qrCodeUrl()} alt="QR Code" style={{ 'margin-left': '20px' }} />
+              <img src={qrCodeUrl()} alt="QR Code" style={{ 'margin-left': '15px' }} />
             </div>
           </div>
         </CardContent>

--- a/src/components/workspace/own-certificate.tsx
+++ b/src/components/workspace/own-certificate.tsx
@@ -4,11 +4,13 @@ import { Show, createEffect, createSignal } from 'solid-js'
 import { bytesToBase64 } from '../../utils'
 import { Encoder } from '@ndn/tlv'
 import { Certificate } from '@ndn/keychain'
+import { toDataURL } from 'qrcode'
 
 export default function OwnCertificate(props: { certificate: Certificate | undefined }) {
   const [expanded, setExpanded] = createSignal(true)
   const [nameStr, setNameStr] = createSignal('')
   const [certText, setCertText] = createSignal('')
+  const [qrCodeUrl, setQrCodeUrl] = createSignal('')
 
   createEffect(() => {
     const cert = props.certificate
@@ -32,6 +34,17 @@ export default function OwnCertificate(props: { certificate: Certificate | undef
     }
   })
 
+  // Generate QR-Code when certText change
+  createEffect(() => {
+    toDataURL(certText(), { errorCorrectionLevel: 'M' }) // TODO: hardcoded error-level
+      .then((url) => {
+        setQrCodeUrl(url)
+      })
+      .catch((e) => {
+        console.error('Error generating QR code', e)
+      })
+  })
+
   return (
     <Card>
       <CardHeader
@@ -53,22 +66,27 @@ export default function OwnCertificate(props: { certificate: Certificate | undef
       <Show when={expanded()}>
         <Divider />
         <CardContent>
-          <TextField
-            fullWidth
-            multiline
-            label="My Certificate"
-            name="certificate"
-            type="text"
-            rows={10}
-            inputProps={{
-              // readOnly: true,  // readOnly does not work with multiline
-              style: {
-                'font-family': '"Roboto Mono", ui-monospace, monospace',
-                'white-space': 'pre',
-              },
-            }}
-            value={certText()}
-          />
+          <div style={{ display: 'flex', 'align-items': 'flex-start' }}>
+            <TextField
+              fullWidth
+              multiline
+              label="My Certificate"
+              name="certificate"
+              type="text"
+              rows={10}
+              inputProps={{
+                // readOnly: true,  // readOnly does not work with multiline
+                style: {
+                  'font-family': '"Roboto Mono", ui-monospace, monospace',
+                  'white-space': 'pre',
+                },
+              }}
+              value={certText()}
+            />
+            <div>
+              <img src={qrCodeUrl()} alt="QR Code" style={{ 'margin-left': '20px' }} />
+            </div>
+          </div>
         </CardContent>
       </Show>
     </Card>

--- a/src/components/workspace/qr-gen.tsx
+++ b/src/components/workspace/qr-gen.tsx
@@ -6,7 +6,7 @@ export default function CertQrCode(props: { value: string }) {
 
   createEffect(() => {
     if (props.value) {
-      qrcode.toDataURL(props.value, { errorCorrectionLevel: 'L' }, (error, dataUrl) => {
+      qrcode.toDataURL(props.value, { errorCorrectionLevel: 'M' }, (error, dataUrl) => {
         if (error) {
           console.error('Unable to generate QRCode:', error)
         } else {


### PR DESCRIPTION
- Added QR Code display for workspace trust anchor (`app-namespace.tsx`)
- Added QR Code display for user certificate (`own-certificate.tsx`)
- Used existing `qr-gen.tsx` structure
  - changed the errorCorrectionLevel from `L` to `M`

- resolves #87 .