### PR TITLE
update home page instructions and minors

### DIFF
--- a/build-meta.bash
+++ b/build-meta.bash
@@ -1,7 +1,11 @@
 revision="$(git describe --tags --abbrev=0) $(git rev-parse --short HEAD)"
-timestamp=$(date +%s.%N)
+timestamp=$(date +%s)
 echo '{"revision":"'${revision}'","timestamp":'${timestamp}'}' > ./public/build-meta.json
 echo 'export const REVISION = '"'"${revision}"'" \
   '\n// eslint-disable-next-line @typescript-eslint/no-loss-of-precision, prettier/prettier' \
   '\nexport const TIMESTAMP = '${timestamp} > ./src/build-meta.ts
-sed -i -r 's/([^ \t]+)[ \t]+$/\1/' ./src/build-meta.ts
+if [[ $SHELL == *"zsh" ]]; then
+  sed -i -r 's/\([^ \t]+\)[ \t]+$/\1/' ./src/build-meta.ts
+else
+  sed -i -r 's/([^ \t]+)[ \t]+$/\1/' ./src/build-meta.ts
+fi

--- a/public/build-meta.json
+++ b/public/build-meta.json
@@ -1,1 +1,1 @@
-{"revision":"d5a1a2f","timestamp":1719122331.228639166}
+{"revision":" 1070b50","timestamp":1721063156}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,21 +166,6 @@ function App() {
           </>
           <>
             <Typography variant="h5" sx={{ mb: 1, mt: 3, fontWeight: 100 }}>
-              Join a Workspace
-            </Typography>
-            To join an existing Workspace, perform the following steps after ensuring you are connected to the NDN
-            testbed.
-            <ol>
-              <li>Open the "Workspace" tab</li>
-              <li>Click on the "Convert" button</li>
-              <li>Enter the full trust anchor name of the workspace</li>
-              <li>Click on the "Join" button</li>
-            </ol>
-            You can now join the workspace any time from the "Workspace" tab, and start collaborating on documents in
-            the "Editor" tab.
-          </>
-          <>
-            <Typography variant="h5" sx={{ mb: 1, mt: 3, fontWeight: 100 }}>
               Create a Workspace
             </Typography>
             To create a new Workspace, you need to generate a trust anchor that identifies the Workspace and the user
@@ -240,6 +225,51 @@ function App() {
               </li>
 
               <li>Click on the "Join" button to create the workspace.</li>
+            </ol>
+          </>
+          <>
+            <Typography variant="h5" sx={{ mb: 1, mt: 3, fontWeight: 100 }}>
+              Join a Workspace
+            </Typography>
+            To join an existing workspace instance, ask the instance owner for the trust anchor, and coordinate with the
+            owner to have a username within the instance. Assuming the owner plan to name you as bob, then perform the
+            following steps to generate a certificate signing request.
+            <ol>
+              <li>
+                Generate a key and certificate for <code>/my-workspace/alice</code>
+                <code style={{ 'padding-left': '15px', display: 'block' }}>
+                  ndnsec key-gen /my-workspace/bob <br />
+                  ndnsec sign-req /my-workspace/bob &gt; bob.csr <br />
+                </code>
+              </li>
+              <li>
+                Send bob.csr to the owner, and let the owner perform the following step and send back the signed
+                certficate generated from below.
+                <code style={{ 'padding-left': '15px', display: 'block' }}>
+                  ndnsec cert-gen -s /my-workspace -i my-workspace bob.csr &gt; bob.cert
+                </code>
+              </li>
+              <li>
+                Install the certificate and export the identity into safebag.
+                <code style={{ 'padding-left': '15px', display: 'block' }}>
+                  ndnsec cert-install bob.cert <br />
+                </code>
+              </li>
+              <li>
+                Open the app, goto the workspace tab, click add profile (icon in the top right corner), the app will ask
+                you to configure trust anchor (obtained from the instance owner) and safebag, which is the combination
+                of certificate and encrypted private key.
+                <div style={{ 'padding-left': '15px' }}>
+                  Generate safebag: <code>ndnsec export -i /my-workspace/bob</code>
+                </div>
+                <small>
+                  The terminal will ask you for a passphrase for encrypting your private key. Make sure you input the
+                  same passphrase when configuring your safebag in the app.
+                </small>
+              </li>
+              <li>Click on the "Join" button to create the workspace.</li>
+              You can now join the workspace any time from the "Workspace" tab, and start collaborating on documents in
+              the "Editor" tab.
             </ol>
           </>
           <>

--- a/src/build-meta.ts
+++ b/src/build-meta.ts
@@ -1,3 +1,3 @@
-export const REVISION = 'd5a1a2f'
-// eslint-disable-next-line @typescript-eslint/no-loss-of-precision, prettier/prettier
-export const TIMESTAMP = 1719122331.228639166
+export const REVISION = ' 1070b50' 
+// eslint-disable-next-line @typescript-eslint/no-loss-of-precision, prettier/prettier 
+export const TIMESTAMP = 1721063156

--- a/src/components/workspace/convert-testbed.tsx
+++ b/src/components/workspace/convert-testbed.tsx
@@ -82,19 +82,13 @@ export default function ConvertTestbed() {
 
   return (
     <Card>
-      <CardHeader
-        sx={{ textAlign: 'left' }}
-        title="Convert Testbed Cert as Workspace Identity"
-        subheader={
-          <Typography color="primary" fontFamily='"Roboto Mono", ui-monospace, monospace'>
-            /ndn/multicast/workspace-test
-          </Typography>
-        }
-      />
+      <CardHeader sx={{ textAlign: 'left' }} title="Convert Testbed Cert as Workspace Identity" />
       <Divider />
       <CardContent>
-        This page will let you convert a testbed certificate into a workspace certificate using proof-of-possession.
-        Please connect to the testbed with a valid certificate and provide the full name of the trust anchor.
+        This is designed for Workspace instances which have CAs reachable through testbed. Please refer to home page on
+        how to join normal Workspace instances. This page will let you convert a testbed certificate into a workspace
+        certificate using proof-of-possession. Please connect to the testbed with a valid certificate and provide the
+        full name of the trust anchor.
       </CardContent>
       <Divider />
       <CardContent>


### PR DESCRIPTION
This PR updates the homepage and convert page instructions as suggested in #113. Also some minor fixes in `build-meta.sh` for OSX platform (see below)

`date` in OSX doesn't have `%N` and it seems removing it does hurt, so I removed it. Also default bash on OSX is zsh where one needs to escape parenthesis (CMIIW).