### PR TITLE
Added instructions to convert text to QR code on linux-based OS's

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,6 +206,17 @@ function App() {
                 </small>
               </li>
 
+              <li>
+                For convenience, you can store trust anchors and safebags in QR code and scan them for quick fill-in. On
+                Linux-based OS's, the following command converts text to QR code (using trust anchor as example):
+                <div style={{ 'padding-left': '15px' }}>
+                  <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
+                </div>
+                <small>
+                  To install the necessary packages, use the command <code>apt install</code>
+                </small>
+              </li>
+
               <li>Click on the "Join" button to create the workspace.</li>
             </ol>
           </>
@@ -247,6 +258,16 @@ function App() {
                 <small>
                   The terminal will ask you for a passphrase for encrypting your private key. Make sure you input the
                   same passphrase when configuring your safebag in the app.
+                </small>
+              </li>
+              <li>
+                You may also store and scan your credentials in QR Code. On Linux-based OS's, the following command
+                converts text to QR code (using trust anchor as example):
+                <div style={{ 'padding-left': '15px' }}>
+                  <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
+                </div>
+                <small>
+                  To install the necessary packages, use the command <code>apt install</code>
                 </small>
               </li>
               <li>Click on the "Join" button to create the workspace.</li>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -210,17 +210,14 @@ function App() {
                 If you have a display, you may also store trust anchors and safebags in QR code and scan them for quick
                 fill-in. On Linux-based OS's, the following command displays texts in QR Code:
                 <div style={{ 'padding-left': '15px' }}>
-                  To install the packages, run <code>apt install qrencode feh</code>. You may need to put{' '}
-                  <code>sudo</code> at front depending on your setup <br />
-                  To display the QR code, run <code>
-                    ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -
-                  </code>{' '}
-                  <br />
-                  <small>
-                    Here we use trust anchor as example, replace the first part (before the first '|') with safebag
-                    generation to get the QR code for safebag.
-                  </small>
+                  Install the packages: <code>apt install qrencode feh</code>. You may need to put <code>sudo</code> at
+                  front depending on your setup <br />
+                  Display the QR code: <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
                 </div>
+                <small>
+                  Here we use trust anchor as example, replace the first part (before the first '|') with safebag
+                  generation to get the QR code for safebag.
+                </small>
               </li>
 
               <li>Click on the "Join" button to create the workspace.</li>
@@ -270,17 +267,14 @@ function App() {
                 If you have a display, you may also store trust anchors and safebags in QR code and scan them for quick
                 fill-in. On Linux-based OS's, the following command displays texts in QR Code:
                 <div style={{ 'padding-left': '15px' }}>
-                  To install the packages, run <code>apt install qrencode feh</code>. You may need to put{' '}
-                  <code>sudo</code> at front depending on your setup <br />
-                  To display the QR code, run <code>
-                    ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -
-                  </code>{' '}
-                  <br />
-                  <small>
-                    Here we use trust anchor as example, replace the first part (before the first '|') with safebag
-                    generation to get the QR code for safebag.
-                  </small>
+                  Install the packages: <code>apt install qrencode feh</code>. You may need to put <code>sudo</code> at
+                  front depending on your setup <br />
+                  Display the QR code: <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
                 </div>
+                <small>
+                  Here we use trust anchor as example, replace the first part (before the first '|') with safebag
+                  generation to get the QR code for safebag.
+                </small>
               </li>
               <li>Click on the "Join" button to create the workspace.</li>
               You can now join the workspace any time from the "Workspace" tab, and start collaborating on documents in

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,14 +207,13 @@ function App() {
               </li>
 
               <li>
-                For convenience, you can store trust anchors and safebags in QR code and scan them for quick fill-in. On
-                Linux-based OS's, the following command converts text to QR code (using trust anchor as example):
+                If you have a display, you may also store trust anchors and safebags in QR code and scan them for quick fill-in. On
+                Linux-based OS's, the following command displays texts in QR Code:
                 <div style={{ 'padding-left': '15px' }}>
-                  <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
+                  To install the packages, run <code>apt install qrencode feh</code>. You may need to put <code>sudo</code> at front depending on your setup <br />
+                  To display the QR code, run <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
+                  <small>Here we use trust anchor as example, replace the first part (before the first '|') with safebag generation to get the QR code for safebag.</small>
                 </div>
-                <small>
-                  To install the necessary packages, use the command <code>apt install</code>
-                </small>
               </li>
 
               <li>Click on the "Join" button to create the workspace.</li>
@@ -261,14 +260,13 @@ function App() {
                 </small>
               </li>
               <li>
-                You may also store and scan your credentials in QR Code. On Linux-based OS's, the following command
-                converts text to QR code (using trust anchor as example):
+                If you have a display, you may also store trust anchors and safebags in QR code and scan them for quick fill-in. On
+                Linux-based OS's, the following command displays texts in QR Code:
                 <div style={{ 'padding-left': '15px' }}>
-                  <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
+                  To install the packages, run <code>apt install qrencode feh</code>. You may need to put <code>sudo</code> at front depending on your setup <br />
+                  To display the QR code, run <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
+                  <small>Here we use trust anchor as example, replace the first part (before the first '|') with safebag generation to get the QR code for safebag.</small>
                 </div>
-                <small>
-                  To install the necessary packages, use the command <code>apt install</code>
-                </small>
               </li>
               <li>Click on the "Join" button to create the workspace.</li>
               You can now join the workspace any time from the "Workspace" tab, and start collaborating on documents in

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,12 +207,19 @@ function App() {
               </li>
 
               <li>
-                If you have a display, you may also store trust anchors and safebags in QR code and scan them for quick fill-in. On
-                Linux-based OS's, the following command displays texts in QR Code:
+                If you have a display, you may also store trust anchors and safebags in QR code and scan them for quick
+                fill-in. On Linux-based OS's, the following command displays texts in QR Code:
                 <div style={{ 'padding-left': '15px' }}>
-                  To install the packages, run <code>apt install qrencode feh</code>. You may need to put <code>sudo</code> at front depending on your setup <br />
-                  To display the QR code, run <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
-                  <small>Here we use trust anchor as example, replace the first part (before the first '|') with safebag generation to get the QR code for safebag.</small>
+                  To install the packages, run <code>apt install qrencode feh</code>. You may need to put{' '}
+                  <code>sudo</code> at front depending on your setup <br />
+                  To display the QR code, run <code>
+                    ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -
+                  </code>{' '}
+                  <br />
+                  <small>
+                    Here we use trust anchor as example, replace the first part (before the first '|') with safebag
+                    generation to get the QR code for safebag.
+                  </small>
                 </div>
               </li>
 
@@ -260,12 +267,19 @@ function App() {
                 </small>
               </li>
               <li>
-                If you have a display, you may also store trust anchors and safebags in QR code and scan them for quick fill-in. On
-                Linux-based OS's, the following command displays texts in QR Code:
+                If you have a display, you may also store trust anchors and safebags in QR code and scan them for quick
+                fill-in. On Linux-based OS's, the following command displays texts in QR Code:
                 <div style={{ 'padding-left': '15px' }}>
-                  To install the packages, run <code>apt install qrencode feh</code>. You may need to put <code>sudo</code> at front depending on your setup <br />
-                  To display the QR code, run <code>ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -</code> <br />
-                  <small>Here we use trust anchor as example, replace the first part (before the first '|') with safebag generation to get the QR code for safebag.</small>
+                  To install the packages, run <code>apt install qrencode feh</code>. You may need to put{' '}
+                  <code>sudo</code> at front depending on your setup <br />
+                  To display the QR code, run <code>
+                    ndnsec cert-dump -i /my-workspace | qrencode -o - | feh -
+                  </code>{' '}
+                  <br />
+                  <small>
+                    Here we use trust anchor as example, replace the first part (before the first '|') with safebag
+                    generation to get the QR code for safebag.
+                  </small>
                 </div>
               </li>
               <li>Click on the "Join" button to create the workspace.</li>


### PR DESCRIPTION
Currently there are no ways to obtain credentials in the form of QR code as mentioned [here](https://github.com/UCLA-IRL/ndn-workspace-solid/pull/117#issuecomment-2244076098).
> Unfortunately adding QR code for safebags on the website does not help. The safebag is obtained **somewhere** and then inputed to workspace for bootstrap. So the most important part is that the **somewhere** should support QR cde display.

This update contains some instructions on converting texts to QR codes in Linux-based environments. Could be a temporary remedy before on-site credential generation is made available