### PR TITLE
Disable `Show QR Code` buttons when the input is not valid

### DIFF
--- a/src/components/workspace/app-namespace.tsx
+++ b/src/components/workspace/app-namespace.tsx
@@ -176,7 +176,7 @@ export default function AppNamespace(props: {
               value={value()}
               onChange={(event) => onChange(event.target.value)}
             />
-            <Button onClick={() => setTaQrOpen(true)} variant="contained">
+            <Button onClick={() => setTaQrOpen(true)} variant="contained" disabled={nameStr() === ''}>
               {' '}
               Show QR Code{' '}
             </Button>

--- a/src/components/workspace/boot-safebag.tsx
+++ b/src/components/workspace/boot-safebag.tsx
@@ -163,7 +163,7 @@ export default function BootSafebag(props: {
               value={safebagText()}
               onChange={(event) => setSafebagText(event.target.value)}
             />
-            <Button onClick={() => setSbagQrOpen(true)} variant="contained">
+            <Button onClick={() => setSbagQrOpen(true)} variant="contained" disabled={nameStr() === ''}>
               {' '}
               Show QR Code{' '}
             </Button>

--- a/src/components/workspace/own-certificate.tsx
+++ b/src/components/workspace/own-certificate.tsx
@@ -82,7 +82,7 @@ export default function OwnCertificate(props: { certificate: Certificate | undef
               }}
               value={certText()}
             />
-            <Button onClick={() => setCertQrOpen(true)} variant="contained">
+            <Button onClick={() => setCertQrOpen(true)} variant="contained" disabled={nameStr() === ''}>
               {' '}
               Show QR Code{' '}
             </Button>


### PR DESCRIPTION
This should come with the QR display update, apology.

Now the buttons are only enabled when the inputs are valid (base64, non-empty, parsed successfully, etc.), this should reduce potential confusion and make the page look more consistent