### PR TITLE
Fix some PDF related issues

### DIFF
--- a/build-meta.bash
+++ b/build-meta.bash
@@ -1,7 +1,8 @@
+#!/bin/bash
 revision="$(git describe --tags --abbrev=0) $(git rev-parse --short HEAD)"
 timestamp=$(date +%s)
 echo '{"revision":"'${revision}'","timestamp":'${timestamp}'}' > ./public/build-meta.json
-echo 'export const REVISION = '"'"${revision}"'" \
+echo -e 'export const REVISION = '"'"${revision}"'" \
   '\n// eslint-disable-next-line @typescript-eslint/no-loss-of-precision, prettier/prettier' \
   '\nexport const TIMESTAMP = '${timestamp} > ./src/build-meta.ts
 if [[ $SHELL == *"zsh" ]]; then

--- a/src/components/share-latex/app-tools.tsx
+++ b/src/components/share-latex/app-tools.tsx
@@ -29,7 +29,12 @@ export default function AppTools(props: {
           <MenuIcon />
         </IconButton>
         <div style={{ 'flex-grow': 1 }}>
-          <PathBread rootPath={props.rootPath} pathIds={props.pathIds} resolveName={props.resolveName} />
+          <PathBread
+            rootPath={props.rootPath}
+            pathIds={props.pathIds}
+            resolveName={props.resolveName}
+            setView={props.setView}
+          />
         </div>
         <Button onClick={props.onCompile}>Compile</Button>
         <Select

--- a/src/components/share-latex/path-bread.tsx
+++ b/src/components/share-latex/path-bread.tsx
@@ -1,11 +1,13 @@
 import { Breadcrumbs, Link, Typography } from '@suid/material'
 import HomeIcon from '@suid/icons-material/Home'
-import { For, Match, Show, Switch } from 'solid-js'
+import { For, Match, Show, Switch, Setter } from 'solid-js'
+import { ViewValues } from './types'
 
 export default function PathBread(props: {
   rootPath: string
   pathIds: string[]
   resolveName: (id: string) => string | undefined
+  setView: Setter<ViewValues>
 }) {
   return (
     <Breadcrumbs>
@@ -14,6 +16,12 @@ export default function PathBread(props: {
           const isFirst = () => index() === 0
           const isLast = () => index() === props.pathIds.length - 1
           const to = () => props.rootPath + '/' + value
+
+          const handleClick = () => {
+            // Force Setview to Editor after click path
+            props.setView('Editor')
+          }
+
           return (
             <Switch>
               <Match when={isLast()}>
@@ -26,7 +34,13 @@ export default function PathBread(props: {
                 </Typography>
               </Match>
               <Match when={!isLast()}>
-                <Link underline="hover" sx={{ display: 'flex', alignItems: 'center' }} color="inherit" href={to()}>
+                <Link
+                  underline="hover"
+                  sx={{ display: 'flex', alignItems: 'center' }}
+                  color="inherit"
+                  href={to()}
+                  onClick={handleClick}
+                >
                   <Show when={isFirst()} fallback={props.resolveName(value)}>
                     <>
                       <HomeIcon sx={{ mr: 0.5 }} fontSize="inherit" /> ROOT

--- a/src/components/share-latex/share-latex/component.tsx
+++ b/src/components/share-latex/share-latex/component.tsx
@@ -7,7 +7,7 @@ import { project } from '../../../backend/models'
 import { Accessor, Match, Setter, Show, Switch, createSignal } from 'solid-js'
 import RichDoc from '../rich-doc'
 import { ViewValues } from '../types'
-import PdfViewer from '../pdf-viewer/pdf-viewer'
+import PDFViewer from '../simple-pdf/pdf-viewer'
 import styles from './styles.module.scss'
 import { NdnSvsAdaptor } from '@ucla-irl/ndnts-aux/adaptors'
 import RenameItem from '../rename-item'
@@ -161,7 +161,15 @@ export default function ShareLatexComponent(props: {
               'w-half': props.view() === 'Both',
             }}
           >
-            {props.pdfUrl ? <PdfViewer pdfUrl={props.pdfUrl} /> : <div />}
+            <div class={styles.pdf}>
+              {props.pdfUrl ? (
+                <div>
+                  <PDFViewer pdfUrl={props.pdfUrl} />
+                </div>
+              ) : (
+                <div />
+              )}
+            </div>
           </div>
         </Show>
         <Show when={props.view() === 'Log'}>

--- a/src/components/share-latex/share-latex/styles.module.scss
+++ b/src/components/share-latex/share-latex/styles.module.scss
@@ -20,4 +20,12 @@
     border-radius: 4px;
     padding: 8px;
   }
+
+  .pdf {
+    height: 100%;
+    overflow: auto;
+    border: 1px;
+    border-radius: 4px;
+    padding: 8px;
+  }
 }

--- a/src/components/share-latex/simple-pdf/pdf-viewer.tsx
+++ b/src/components/share-latex/simple-pdf/pdf-viewer.tsx
@@ -1,0 +1,21 @@
+import { Component } from 'solid-js'
+
+interface PDFViewerProps {
+  pdfUrl: string
+  width?: string
+  height?: string
+}
+
+const PDFViewer: Component<PDFViewerProps> = (props) => {
+  return (
+    <iframe
+      src={props.pdfUrl}
+      width={props.width || '100%'}
+      height={props.height || '800px'}
+      style={{ border: 'none' }}
+      title="PDF Viewer"
+    />
+  )
+}
+
+export default PDFViewer


### PR DESCRIPTION
1. f0d465091f33726bf6f1be73a7e2fbc0685e108b Fixed the `./build-meta.bash: 7: [[: not found` error occurring in both `pnpm dev` and `build` processes.

2. 623e35c7fe54208627f3b9fe563417ec9a627ade Resolved an issue where navigating to another view (PDF, both, log) and clicking on a path did not automatically redirect to the editor view, which was unintended behavior.

3. fa7ade7c76086a09e4097384d709e64c2e9f9295 Fixed issues with PDF display and the functionality of the both view. Most modern desktop browsers support using iframes to display PDF files, which is not supported by mobile browsers. However this is still a big improvement over the previous not usable state (Before the pdf view will freeze the whole page except the nav bar and not work on both view). The pdfslick dependency was retained and can be removed in the future.