### PR TITLE
fix: disable dark mode in rich doc

### DIFF
--- a/src/components/share-latex/rich-doc/index.tsx
+++ b/src/components/share-latex/rich-doc/index.tsx
@@ -203,7 +203,7 @@ export default function RichDoc(props: {
         </Stack>
       </CardContent>
       <Divider />
-      <CardContent sx={{ flex: 1 }}>
+      <CardContent sx={{ flex: 1, backgroundColor: "#FFFFFF" }}>
         <div id="editor" class={styles.editor} ref={setContainer} />
       </CardContent>
     </Card>


### PR DESCRIPTION
![{1D3DBDD4-E19D-490F-96B9-C4F05B8C87FC}](https://github.com/user-attachments/assets/2a6432d9-5aeb-46f7-8585-ad33ac1451e7)
![{0F3C3C2D-4694-4C95-88DD-25462CDE6C0E}](https://github.com/user-attachments/assets/69baaf86-a4f6-4129-9069-7fb59b3d85a2)
