### PR TITLE
fix: retry prefix registration

### DIFF
--- a/src/components/share-latex/rich-doc/index.tsx
+++ b/src/components/share-latex/rich-doc/index.tsx
@@ -203,7 +203,7 @@ export default function RichDoc(props: {
         </Stack>
       </CardContent>
       <Divider />
-      <CardContent sx={{ flex: 1, backgroundColor: "#FFFFFF" }}>
+      <CardContent sx={{ flex: 1, backgroundColor: '#FFFFFF' }}>
         <div id="editor" class={styles.editor} ref={setContainer} />
       </CardContent>
     </Card>


### PR DESCRIPTION
Currently only one attempt is made for prefix registration. If any Interest gets dropped the connection is closed. Unless the command indicates an explicit error, we should retry it.