### PR TITLE
UI Improvements to Workspace Chat

### DIFF
--- a/src/components/chat/add-channel-dialog.tsx
+++ b/src/components/chat/add-channel-dialog.tsx
@@ -1,0 +1,63 @@
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Checkbox, FormControlLabel } from '@suid/material'
+import { createSignal } from 'solid-js'
+
+interface AddChannelDialogProps {
+  open: boolean
+  onClose: () => void
+  onConfirm: (channelName: string) => void
+}
+
+export function AddChannelDialog(props: AddChannelDialogProps) {
+  const [channelName, setChannelName] = createSignal('')
+  const [confirmed, setConfirmed] = createSignal(false)
+
+  const handleSubmit = () => {
+    if (channelName().trim() && confirmed()) {
+      props.onConfirm(channelName().trim())
+      setChannelName('')
+      setConfirmed(false)
+    }
+  }
+
+  const handleClose = () => {
+    setChannelName('')
+    setConfirmed(false)
+    props.onClose()
+  }
+
+  return (
+    <Dialog open={props.open} onClose={handleClose}>
+      <DialogTitle>Add New Channel</DialogTitle>
+      <DialogContent>
+        <div style={{ display: 'flex', 'flex-direction': 'column', gap: '1rem', 'min-width': '300px', 'margin-top': '1rem' }}>
+          <TextField
+            autoFocus
+            label="Channel Name"
+            value={channelName()}
+            onChange={(e) => setChannelName(e.target.value)}
+            fullWidth
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={confirmed()}
+                onChange={(_, checked) => setConfirmed(checked)}
+              />
+            }
+            label="I understand that this channel cannot be deleted after the first message is sent and cannot be renamed"
+          />
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          onClick={handleSubmit}
+          disabled={!channelName().trim() || !confirmed()}
+          color="primary"
+        >
+          Create Channel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/components/chat/styles.module.scss
+++ b/src/components/chat/styles.module.scss
@@ -28,9 +28,13 @@
 
 .App_header {
   background: #fafafa;
+  border-bottom: 3px solid #e0e0e0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   padding: 15px 25px;
   margin: 0;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 /* Message input section styling */
@@ -61,7 +65,7 @@
 
 /* Send Message button Styling */
 .App__button {
-  background: #007bff;
+  background: #223387;
   padding: 10px 20px;
   border: none;
   color: #fff;
@@ -163,6 +167,8 @@
   border-top-width: 0;
   padding: var(--msg-pad-normal);
   margin-top: 0;
+  background-color: inherit;
+  color: #333;
 }
 
 /* Webkit browsers */
@@ -182,11 +188,13 @@
 
 .ChannelButton {
   background-color: transparent;
-  border: none;
+  border-radius: 20px;
   color: #333;
   cursor: pointer;
   font-size: var(--msg-font-size-header);
-  padding: 8px 16px;
+  outline: 1px solid #223387;
+  padding: 6px 16px;
+  margin-bottom: 8px;
   margin-right: 8px;
   transition: background-color 0.3s;
 
@@ -196,16 +204,28 @@
 }
 
 .ActiveChannelButton {
-  background-color: #007bff;
+  background-color: #223387;
   border: none;
+  border-radius: 20px;
   color: white;
   cursor: pointer;
   font-size: var(--msg-font-size-header);
-  padding: 8px 16px;
+  outline: 1px solid #223387;
+  padding: 6px 16px;
   margin-right: 8px;
+  margin-bottom: 8px;
   transition: background-color 0.3s;
 
   &:hover {
     background-color: #0056b3;
   }
+}
+
+.ChannelHeading {
+  border-left: 3px solid #223387;
+  color: #333;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+  padding-left: 12px;
 }

--- a/src/components/chat/styles.module.scss
+++ b/src/components/chat/styles.module.scss
@@ -221,6 +221,23 @@
   }
 }
 
+.AddChannelButton {
+  background-color: #ddd;
+  border: none;
+  border-radius: 20px;
+  color: black;
+  cursor: pointer;
+  font-size: var(--msg-font-size-header);
+  padding: 6px 14px;
+  margin-right: 8px;
+  margin-bottom: 8px;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: #eee;
+  }
+}
+
 .ChannelHeading {
   border-left: 3px solid #223387;
   color: #333;


### PR DESCRIPTION
Closes #160 
Closes #159 
Related to #161 (but does not close it because I haven't figured out a way to remove channels yet)

Improvements:

* automatically scrolls to bottom upon entering chat
* enter key sends message (shift+enter for newline)
* prevent sending of empty messages
* messages text now readable instead of white 
* added sent time (hh:mm am/pm) in addition to date
* profile pictures are now 1) deterministic across users/devices, 2) different for each sender, can differentiate people by their PFP
* prettified top navigation bar and buttons
* use memos instead of functions for improved rendering efficiency
* new UI and logic to create a chat channel
* chat channels are no longer hardcoded (other than '#general' to avoid user confusion)


New look:
![image](https://github.com/user-attachments/assets/a02b6920-2704-4e87-a81d-7a5b86e7f1ba)

![image](https://github.com/user-attachments/assets/f1b74617-b8cd-4411-ae5f-747f56cff207)

