### PR TITLE
Added flag for deleted files

### DIFF
--- a/src/backend/models/project.ts
+++ b/src/backend/models/project.ts
@@ -21,6 +21,9 @@ export type ItemBase = {
 
   /** The kind of the item. Used to determine which page is used to view it. */
   kind: string
+
+  /** Whether the file has been deleted or not. Used to distinguish between current and historical files of the same name. */
+  deleted: boolean
 }
 
 export type Folder = ItemBase & {

--- a/src/components/share-latex/share-latex/index.tsx
+++ b/src/components/share-latex/share-latex/index.tsx
@@ -91,7 +91,12 @@ export default function ShareLatex(props: { rootUri: string }) {
 
   const deleteItem = (index: number) => {
     const cur = item()
+    const rootDocVal = rootDoc()
     if (cur?.kind === 'folder') {
+      const curItem = rootDocVal!.latex[cur.items[index]]
+      if (curItem !== undefined) {
+        curItem!.deleted = true
+      }
       cur.items.splice(index, 1)
       // The root document is not modified, so the person editting this file will not be affected.
     }
@@ -134,6 +139,7 @@ export default function ShareLatex(props: { rootUri: string }) {
             kind: 'folder',
             // fullPath: cur.fullPath + '/' + name,
             name: name,
+            deleted: false,
             parentId: cur.id,
             items: [],
           }
@@ -149,6 +155,7 @@ export default function ShareLatex(props: { rootUri: string }) {
             kind: 'text',
             // fullPath: cur.fullPath + '/' + name,
             name: name,
+            deleted: false,
             parentId: cur.id,
             text: new Y.Text(),
           }
@@ -163,6 +170,7 @@ export default function ShareLatex(props: { rootUri: string }) {
             kind: 'xmldoc',
             // fullPath: cur.fullPath + '/' + name,
             name: newName,
+            deleted: false,
             parentId: cur.id,
             text: new Y.XmlFragment(),
           }
@@ -177,6 +185,7 @@ export default function ShareLatex(props: { rootUri: string }) {
             kind: 'markdowndoc',
             // fullPath: cur.fullPath + '/' + name,
             name: newName,
+            deleted: false,
             parentId: cur.id,
             prosemirror: new Y.XmlFragment(),
           }
@@ -193,6 +202,7 @@ export default function ShareLatex(props: { rootUri: string }) {
                 kind: 'blob',
                 // fullPath: cur.fullPath + '/' + name,
                 name: name,
+                deleted: false,
                 parentId: cur.id,
                 blobName: blobName.toString(),
               }


### PR DESCRIPTION
Currently, the yjs does not distinguish between deleted files and non-deleted files. This means that if a file is deleted and replaced by a new file with the same name, there is no way to tell which is which. This change should allow for workspaces such as the weekly meeting document workspace that only host one file to be more resistant to mistakes (the main file there was already deleted multiple times)

Note: Retry of a previous pull request where I ran into many issues, had to create a new fork to fix.